### PR TITLE
Removed `ring` implementation completely

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 lazy_static = { version = "1.1", optional = true }
-cpufeatures = { version = "0.2", optional = true }
-ring = "0.17"
 sha2 = "0.10"
 
 [dev-dependencies]
@@ -23,6 +21,5 @@ rustc-hex = "2"
 wasm-bindgen-test = "0.3.33"
 
 [features]
-default = ["zero_hash_cache", "detect-cpufeatures"]
+default = ["zero_hash_cache"]
 zero_hash_cache = ["lazy_static"]
-detect-cpufeatures = ["cpufeatures"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,14 @@ pub const HASH_LEN: usize = 32;
 
 /// Returns the digest of `input` using the best available implementation.
 pub fn hash(input: &[u8]) -> Vec<u8> {
-    DynamicImpl::best().hash(input)
+    Sha2CrateImpl.hash(input)
 }
 
 /// Hash function returning a fixed-size array (to save on allocations).
 ///
 /// Uses the best available implementation based on CPU features.
 pub fn hash_fixed(input: &[u8]) -> [u8; HASH_LEN] {
-    DynamicImpl::best().hash_fixed(input)
+    Sha2CrateImpl.hash_fixed(input)
 }
 
 /// Compute the hash of two slices concatenated.
@@ -71,6 +71,31 @@ impl Sha256Context for sha2::Sha256 {
     }
 }
 
+/// Context encapsulating all implemenation contexts.
+///
+/// This enum ends up being 8 bytes larger than the largest inner context.
+pub enum DynamicContext {
+    Sha2(sha2::Sha256),
+}
+
+impl Sha256Context for DynamicContext {
+    fn new() -> Self {
+        Self::Sha2(Sha256Context::new())
+    }
+
+    fn update(&mut self, bytes: &[u8]) {
+        match self {
+            Self::Sha2(ctxt) => Sha256Context::update(ctxt, bytes),
+        }
+    }
+
+    fn finalize(self) -> [u8; HASH_LEN] {
+        match self {
+            Self::Sha2(ctxt) => Sha256Context::finalize(ctxt),
+        }
+    }
+}
+
 impl Sha256 for Sha2CrateImpl {
     type Context = sha2::Sha256;
 
@@ -80,125 +105,6 @@ impl Sha256 for Sha2CrateImpl {
 
     fn hash_fixed(&self, input: &[u8]) -> [u8; HASH_LEN] {
         Self::Context::digest(input).into()
-    }
-}
-
-/// Implementation of SHA256 using the `ring` crate (fastest on CPUs without SHA extensions).
-pub struct RingImpl;
-
-impl Sha256Context for ring::digest::Context {
-    fn new() -> Self {
-        Self::new(&ring::digest::SHA256)
-    }
-
-    fn update(&mut self, bytes: &[u8]) {
-        self.update(bytes)
-    }
-
-    fn finalize(self) -> [u8; HASH_LEN] {
-        let mut output = [0; HASH_LEN];
-        output.copy_from_slice(self.finish().as_ref());
-        output
-    }
-}
-
-impl Sha256 for RingImpl {
-    type Context = ring::digest::Context;
-
-    fn hash(&self, input: &[u8]) -> Vec<u8> {
-        ring::digest::digest(&ring::digest::SHA256, input)
-            .as_ref()
-            .into()
-    }
-
-    fn hash_fixed(&self, input: &[u8]) -> [u8; HASH_LEN] {
-        let mut ctxt = Self::Context::new(&ring::digest::SHA256);
-        ctxt.update(input);
-        ctxt.finalize()
-    }
-}
-
-/// Default dynamic implementation that switches between available implementations.
-pub enum DynamicImpl {
-    Sha2,
-    Ring,
-}
-
-// Runtime latch for detecting the availability of SHA extensions on x86_64.
-//
-// Inspired by the runtime switch within the `sha2` crate itself.
-#[cfg(all(feature = "detect-cpufeatures", target_arch = "x86_64"))]
-cpufeatures::new!(x86_sha_extensions, "sha", "sse2", "ssse3", "sse4.1");
-
-#[inline(always)]
-pub fn have_sha_extensions() -> bool {
-    #[cfg(all(feature = "detect-cpufeatures", target_arch = "x86_64"))]
-    return x86_sha_extensions::get();
-
-    #[cfg(not(all(feature = "detect-cpufeatures", target_arch = "x86_64")))]
-    return false;
-}
-
-impl DynamicImpl {
-    /// Choose the best available implementation based on the currently executing CPU.
-    #[inline(always)]
-    pub fn best() -> Self {
-        if have_sha_extensions() {
-            Self::Sha2
-        } else {
-            Self::Ring
-        }
-    }
-}
-
-impl Sha256 for DynamicImpl {
-    type Context = DynamicContext;
-
-    #[inline(always)]
-    fn hash(&self, input: &[u8]) -> Vec<u8> {
-        match self {
-            Self::Sha2 => Sha2CrateImpl.hash(input),
-            Self::Ring => RingImpl.hash(input),
-        }
-    }
-
-    #[inline(always)]
-    fn hash_fixed(&self, input: &[u8]) -> [u8; HASH_LEN] {
-        match self {
-            Self::Sha2 => Sha2CrateImpl.hash_fixed(input),
-            Self::Ring => RingImpl.hash_fixed(input),
-        }
-    }
-}
-
-/// Context encapsulating all implemenation contexts.
-///
-/// This enum ends up being 8 bytes larger than the largest inner context.
-pub enum DynamicContext {
-    Sha2(sha2::Sha256),
-    Ring(ring::digest::Context),
-}
-
-impl Sha256Context for DynamicContext {
-    fn new() -> Self {
-        match DynamicImpl::best() {
-            DynamicImpl::Sha2 => Self::Sha2(Sha256Context::new()),
-            DynamicImpl::Ring => Self::Ring(Sha256Context::new()),
-        }
-    }
-
-    fn update(&mut self, bytes: &[u8]) {
-        match self {
-            Self::Sha2(ctxt) => Sha256Context::update(ctxt, bytes),
-            Self::Ring(ctxt) => Sha256Context::update(ctxt, bytes),
-        }
-    }
-
-    fn finalize(self) -> [u8; HASH_LEN] {
-        match self {
-            Self::Sha2(ctxt) => Sha256Context::finalize(ctxt),
-            Self::Ring(ctxt) => Sha256Context::finalize(ctxt),
-        }
     }
 }
 


### PR DESCRIPTION
[`ring`](https://github.com/briansmith/ring) package is used to provide an optimized implementation for sha256 hashing algorithm. However:
1. The version of `ring` used does not support riscv32 architecture, which prevents it from being used in the ZK programs
2. There is already an optimized implementation of sha256 in [sp1-patches/sha256](https://github.com/sp1-patches/RustCrypto-hashes)

Hence, a straightforward solution is to remove `ring` dependency from ethereum_hashes. 

A long(er)-term solution would likely be to make ring support riscv32 (especially since general support for riscv32 seems to be already added in https://github.com/briansmith/ring/issues/2041 - just not he particular architecture used by SP1)... but this is likely a lot more involving